### PR TITLE
Wally command destroy authentication 

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm 1.9.2@wally
+rvm 1.9.2@wally --create

--- a/bin/wally
+++ b/bin/wally
@@ -19,8 +19,8 @@ elsif ARGV[0] == "push"
     end
     features << {:path => feature_path, :gherkin => gherkin}
   end
-  RestClient.put "#{ARGV[1]}/features/?authentication_code=#{File.read(".wally")}", features.to_json, {:content_type => :json, :accept => :json}
+  RestClient.put "#{ARGV[1]}/features/?authentication_code=#{File.read(".wally").strip}", features.to_json, {:content_type => :json, :accept => :json}
 elsif ARGV[0] == "destroy"
   require "restclient"
-  RestClient.delete ARGV[1]
+  RestClient.delete "#{ARGV[1]}?authentication_code=#{File.read(".wally").strip}"
 end


### PR DESCRIPTION
The destroy command did not pass along the authentication code to the server so 301 was raised by Wally.

I also updated the rvmrc to create the gemset once the file has been trusted.

Matt
