### PR TITLE
Corrected search path URL

### DIFF
--- a/lib/wally/views/progress.haml
+++ b/lib/wally/views/progress.haml
@@ -7,7 +7,7 @@
     - tag_count.each do |tag, count|
     - ratio = (count.to_f / scenario_count) * 100
       %li{:class => "#{tag.downcase.gsub("@", "")}"}
-        %a{:href => "/search?q=#{tag}"}
+        %a{:href => "/projects/#{current_project.name}/search?q=#{tag}"}
           = "#{tag} (#{ratio.ceil}%)"
         %span{:class => "count #{tag}"}
           = ratio.ceil


### PR DESCRIPTION
On the progress page, clicking any tags would result in a 404 (/search?q=@tag). This patch adds the /projects/$projects path to address this.
