### PR TITLE
Use ENV variable for key when .wally not present.

### DIFF
--- a/lib/wally/application.rb
+++ b/lib/wally/application.rb
@@ -63,7 +63,11 @@ def highlighted_search_result_blurb search_result
 end
 
 def authenticated?
-  File.exist?(".wally") && params[:authentication_code] == File.read(".wally").strip
+  if File.exist?(".wally")
+    params[:authentication_code] == File.read(".wally").strip
+  else
+    params[:authentication_code] == ENV['WALLY']
+  end
 end
 
 def get_scenario_url(scenario)


### PR DESCRIPTION
It's not really a good idea to commit secrets into source control, which deploying wally to heroku currently requires, this works around that by opting back to an ENV variable when there's no .wally file present.

An even nicer alternative would be to always rely on an ENV variable and use something like Dotenv to load the ENV locally.
