### PR TITLE
add scenario_outline count to progress feature

### DIFF
--- a/lib/wally/application.rb
+++ b/lib/wally/application.rb
@@ -41,6 +41,9 @@ def scenario_count
     if feature.gherkin["elements"]
       count += feature.gherkin["elements"].select { |e| e["type"] == "scenario" }.size
     end
+    if feature.gherkin["elements"]
+      count += feature.gherkin["elements"].select { |e| e["type"] == "scenario_outline" }.size
+    end
     count
   end
 end


### PR DESCRIPTION
i tried Wally and its a great tool, found that 'progress' feature gives the count of only scenarios and scenario_outline count is not included. This gives wrong percentage of the test coverage based on tags.
I have fixed this and verified that its working. 
