### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/wally.gemspec
+++ b/wally.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Cucumber feature viewer and navigator}
   s.description = %q{Cucumber feature viewer and navigator}
 
-  s.rubyforge_project = "wally"
-
   s.files         = `git ls-files`.split("\n")
   s.files << "README.md"
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436